### PR TITLE
Set minimumReleaseAge to 3 days

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,6 +14,7 @@
   "commitMessageExtra": "from {{currentVersion}} to {{newVersion}}",
   "commitMessageTopic": "{{#if isGroup}}the {{groupName}} group{{else}}{{depName}}{{/if}}",
   "commitMessageSuffix": "{{#if isGroup}}with {{upgrades.length}} updates{{/if}}",
+  "minimumReleaseAge": "3 days",
   "packageRules": [
     {
       "matchManagers": "npm",
@@ -32,7 +33,7 @@
         "wrangler",
         "@cloudflare/*"
       ],
-      "groupName": "cloudflare",
+      "groupName": "cloudflare"
     }
   ]
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,4 @@ allowBuilds:
   sharp: false
   unrs-resolver: false
   workerd: false
+minimumReleaseAge: 4320


### PR DESCRIPTION
Sets minimumReleaseAge to 3 days to prepare for supply-chain attack and possibility of unpublishing package.

ref:
https://docs.npmjs.com/policies/unpublish#packages-published-less-than-72-hours-ago
https://docs.renovatebot.com/configuration-options/#prevent-holding-broken-npm-packages